### PR TITLE
Overwrite Brewfile when updating rather than appending

### DIFF
--- a/homebrew/backup-homebrew.sh
+++ b/homebrew/backup-homebrew.sh
@@ -8,4 +8,4 @@
   brew cask list | while read item; do echo "cask install $item"; done
 
   echo "cleanup";
-} >> Brewfile
+} > Brewfile


### PR DESCRIPTION
You'll notice in your [Brewfile](https://github.com/ninjabiscuit/dotfiles/blob/master/homebrew/Brewfile#L96) you have the same contents repeated 3 times, this is because the backup script is appending to the file rather than overwriting. 

This patch fixes that :smile:
